### PR TITLE
revise raster_plot

### DIFF
--- a/functions/geospatial_plot.py
+++ b/functions/geospatial_plot.py
@@ -19,6 +19,7 @@ from matplotlib.colors import ListedColormap
 from matplotlib.patches import Patch
 from matplotlib.lines import Line2D
 import matplotlib.colors as colors
+plt.ion()
 
 # Plot GRU boundary
 def plot_gru_bound(gru_shp,stream_shp,wgs_crs,title,ofile):
@@ -46,8 +47,8 @@ def plot_gru_bound(gru_shp,stream_shp,wgs_crs,title,ofile):
     ax.set_ylabel('Latitude')
     ax.legend(loc='best', framealpha=0.6, facecolor=None)
     fig.savefig(ofile, bbox_inches='tight',dpi=150)    
-
     plt.show()   
+
     return
 
 # Plot GRU and HRU boundary with elevation as background


### PR DESCRIPTION
The raster plot mismatch issue is fixed by adding "norm" instance to the plot function "rasterio.plot.show". Norm is used to assign each color to a bin. The bin list is based on the unique values of the raster data. References are listed below.
https://www.earthdatascience.org/courses/scientists-guide-to-plotting-data-in-python/plot-spatial-data/customize-raster-plots/customize-matplotlib-raster-maps/ 
https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html